### PR TITLE
Added ability to display weekday and month and their short names in uppercase.

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -49,13 +49,17 @@ strftime = (time, formatString) ->
   minute = time.getMinutes()
   second = time.getSeconds()
 
-  formatString.replace /%-?[%aAbBcdeHIlmMpPSwyYZ]/g, (match) ->
+  formatString.replace /%[-\^]?[%aAbBcdeHIlmMpPSwyYZx]/g, (match) ->
     switch match.slice(1)
       when '%'  then '%'
       when 'a'  then weekdays[day].slice 0, 3
+      when '^a'  then weekdays[day].slice(0, 3).toUpperCase()
       when 'A'  then weekdays[day]
+      when '^A'  then weekdays[day].toUpperCase()
       when 'b'  then months[month].slice 0, 3
+      when '^b'  then months[month].slice(0, 3).toUpperCase()
       when 'B'  then months[month]
+      when '^B'  then months[month].toUpperCase()
       when 'c'  then time.toString()
       when 'd'  then pad date
       when '-d' then date


### PR DESCRIPTION
Added the feature where we can display the time as SUNDAY/SUN or JANUARY/JAN manner. This featured is already supported by strftime method of DateTime class by use of  cap(^) symbol. The featured is inspired from the documentation given below.

[https://apidock.com/ruby/DateTime/strftime](https://apidock.com/ruby/DateTime/strftime)

Example: 
`
local_time(DateTime.now, "%d %b %Y at %l:%M %P")   #=>8 Jan 2017 at 10:00 pm (previously)
local_time(DateTime.now, "%d %^b %Y at %l:%M %P")   #=>8 JAN 2017 at 10:00 pm (new feature)

local_time(DateTime.now, "%A, %B %d %Y at %l:%M %p")   #=>#Wednesday, January 03 2018 at 10:15 AM (previously)
local_time(DateTime.now, "%^A, %B %d %Y at %l:%M %p")   #=>#WEDNESDAY, January 03 2018 at 10:15 AM (new feature)
`

where %^b and %^A are the new format string implemented to obtain upcased month and weekday respectively.
